### PR TITLE
Bug fix for test 'Unfound path in constructor error message'

### DIFF
--- a/t/31-trap-fatals.t
+++ b/t/31-trap-fatals.t
@@ -18,7 +18,7 @@ like( $trap->die, qr/Can't locate Foo.Bar.Baz\.pm in \@INC/,
 
 @r = trap { MooseX::amine->new({ path => 'foo/bar/baz.pm' }) };
 is( $trap->leaveby, 'die', 'Unfound path in constructor dies' );
-like( $trap->die, qr/No such file or directory/,
+like( $trap->die, qr/Can't open 'foo.bar.baz\.pm' for reading/,
   'Unfound path in constructor error message' );
 
 @r = trap { MooseX::amine->new({ path => './t/lib/Test/Bad/Foo.pm' }) };


### PR DESCRIPTION
Some of the cpantesters results show that this test fails for non-English locales. The test originally checked for the error response in $! which comes from the O/S and which may be in the language of the user - see eg. http://www.cpantesters.org/cpan/report/c77e9d30-c0a4-11e4-99c5-a688e0bfc7aa
I apologise that my original version did not pick up this possibility.

To mitigate this, the test now looks at the perl-generated part of the error message and tries to match against that instead. I've tested this with a non-English locale (fr_FR) and the test passes.
